### PR TITLE
README example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(url) // => 368668.249914
+	fmt.Println(tk) // => 368668.249914
 }
 ```
 


### PR DESCRIPTION
Fixed compile time error:
```
./google-tts.go:16:2: tk declared and not used
```